### PR TITLE
Update HighPerformanceComputing.md

### DIFF
--- a/HighPerformanceComputing.md
+++ b/HighPerformanceComputing.md
@@ -229,6 +229,12 @@ for later R releases.
     recurrent networks, any combination of both, and custom neural network architectures.
 -   The `r pkg("mvnfast")` uses the sumo random number generator to generate multivariate and normal
     distribtuions in parallel.
+-   The `r pkg("rxode2")` uses parallel processing (via `OpenMP`) for faster solving of ordinary differential 
+    equations (ODEs) over multiple units (grouped by `ID`).  These parallel ODE simulations can also use the 
+    sitmo random number for multiple types of random numbers for each observation and id (like `rxnorm()`, `rinorm()`,  
+    `rxbinom()` etc).
+-   The `r pkg("nlmixr2")` uses parallel ODE solving from `rxode2` to solve nonlinear mixed effects models
+    in parallel (for the algorithm `"saem"`).
 
 ### Parallel computing: GPUs
 

--- a/HighPerformanceComputing.md
+++ b/HighPerformanceComputing.md
@@ -229,11 +229,12 @@ for later R releases.
     recurrent networks, any combination of both, and custom neural network architectures.
 -   The `r pkg("mvnfast")` uses the sumo random number generator to generate multivariate and normal
     distribtuions in parallel.
+-   The `r pkg("rxode2random")` uses the `r pkg("sitmo")` package to generate either truncated or non-truncated 
+    multivariate normal distributions as well as many other common distributions (like binomial, t-distribution etc) 
+    in parallel.  
 -   The `r pkg("rxode2")` uses parallel processing (via `OpenMP`) for faster solving of ordinary differential 
-    equations (ODEs) over multiple units (grouped by `ID`).  These parallel ODE simulations can also use the 
-    sitmo random number for multiple types of random numbers for each observation and id (like `rxnorm()`, `rinorm()`,  
-    `rxbinom()` etc).  The random number generation in `rxode2` is from the support package `r pkg("rxode2random")`, which can be 
-    used independently from `rxode2` and generate truncated multivariate normal distrubutions in parallel.
+    equations (ODEs) over multiple units (grouped by `ID`) and can generate random numbers for each ODE simulation (done
+    automatically with the support package `r pkg("rxode2random")`).
 -   The `r pkg("nlmixr2")` uses parallel ODE solving from `rxode2` to solve nonlinear mixed effects models
     in parallel (for the algorithm `"saem"`).
 

--- a/HighPerformanceComputing.md
+++ b/HighPerformanceComputing.md
@@ -232,7 +232,8 @@ for later R releases.
 -   The `r pkg("rxode2")` uses parallel processing (via `OpenMP`) for faster solving of ordinary differential 
     equations (ODEs) over multiple units (grouped by `ID`).  These parallel ODE simulations can also use the 
     sitmo random number for multiple types of random numbers for each observation and id (like `rxnorm()`, `rinorm()`,  
-    `rxbinom()` etc).
+    `rxbinom()` etc).  The random number generation in `rxode2` is from the support package `r pkg("rxode2random")`, which can be 
+    used independently from `rxode2` and generate truncated multivariate normal distrubutions in parallel.
 -   The `r pkg("nlmixr2")` uses parallel ODE solving from `rxode2` to solve nonlinear mixed effects models
     in parallel (for the algorithm `"saem"`).
 

--- a/HighPerformanceComputing.md
+++ b/HighPerformanceComputing.md
@@ -230,10 +230,10 @@ for later R releases.
 -   The `r pkg("mvnfast")` uses the sumo random number generator to generate multivariate and normal
     distribtuions in parallel.
 -   The `r pkg("rxode2random")` uses the `r pkg("sitmo")` package to generate either truncated or non-truncated 
-    multivariate normal distributions as well as many other common distributions (like binomial, t-distribution etc) 
-    in parallel.  
+    multivariate normal distributions in parallel. The pacakge also generates many other common distributions in parallel (like 
+    binomial, t-distribution etc).  
 -   The `r pkg("rxode2")` uses parallel processing (via `OpenMP`) for faster solving of ordinary differential 
-    equations (ODEs) over multiple units (grouped by `ID`) and can generate random numbers for each ODE simulation (done
+    equations (ODEs) over multiple units (grouped by `ID`) and can generate random numbers for each ODE simulation problem (done
     automatically with the support package `r pkg("rxode2random")`).
 -   The `r pkg("nlmixr2")` uses parallel ODE solving from `rxode2` to solve nonlinear mixed effects models
     in parallel (for the algorithm `"saem"`).


### PR DESCRIPTION
Add parallel ode solving and nonlinear mixed effects.

Note that `rxode2` and other ODE solutions (like `mrgsolve`) compile code for faster solving, but I thought it was a bit out of scope for the section (feel free to agree/disagree here)